### PR TITLE
Add documentation for Attr::is_doc_comment

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -232,6 +232,8 @@ impl AttrItem {
 }
 
 impl Attribute {
+    /// Returns `true` if it is a sugared doc comment (`///` or `//!` for example).
+    /// So `#[doc = "doc"]` will return `false`.
     pub fn is_doc_comment(&self) -> bool {
         match self.kind {
             AttrKind::Normal(..) => false,


### PR DESCRIPTION
The function name was very misleading, some explanations won't hurt.

r? @lqd